### PR TITLE
Fixes for Memory leak on Quit , Fix support for Stream commands, Fix Crash

### DIFF
--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -37,7 +37,7 @@ struct SupportedCommands {
         "xrange", "xrevrange", "rename", "getex", "sort", "zmscore", "sdiffstore", "msetnx", "substr",
         "zrangestore", "zunion", "echo", "zdiff", "xautoclaim", "xinfo", "sunionstore", "smismember",
         "hrandfield", "geosearchstore", "zdiffstore", "geosearch", "randomkey", "zinter", "zrandmember",
-        "bitop", "xclaim", "lpos", "renamenx", "xgroup");
+        "bitop", "xclaim", "lpos", "renamenx", "xgroup","xreadnonblock");
   }
 
   /**
@@ -93,7 +93,7 @@ struct SupportedCommands {
    * @return commands that are called blocking commands but not pubsub commands.
    */
   static const absl::flat_hash_set<std::string>& blockingCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "blpop", "brpop", "brpoplpush", "bzpopmax", "bzpopmin", "xread", "xreadgroup", "blmove");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "blpop", "brpop", "brpoplpush", "bzpopmax", "bzpopmin", "xreadblock", "xreadgroup", "blmove");
   }
 
   /**
@@ -174,6 +174,10 @@ struct SupportedCommands {
    */
   static const std::string& info() { CONSTRUCT_ON_FIRST_USE(std::string, "info"); }
 
+    /**
+   * @return special stream commands
+   */
+  static const std::string& spl_strm_commands() { CONSTRUCT_ON_FIRST_USE(std::string, "xread"); }
   /**
    * @return commands which alters the state of redis
    */

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -33,11 +33,10 @@ struct SupportedCommands {
         "zrangebylex", "zrangebyscore", "zrank", "zrem", "zremrangebylex", "zremrangebyrank",
         "zremrangebyscore", "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan",
         "zscore", "rpoplpush", "smove", "sunion", "sdiff", "sinter", "sinterstore", "zunionstore", 
-        "zinterstore", "pfmerge", "georadius", "georadiusbymember", "xadd", "xlen", "xdel", "xtrim", 
-        "xrange", "xrevrange", "rename", "getex", "sort", "zmscore", "sdiffstore", "msetnx", "substr",
-        "zrangestore", "zunion", "echo", "zdiff", "xautoclaim", "xinfo", "sunionstore", "smismember",
+        "zinterstore", "pfmerge", "georadius", "georadiusbymember", "rename", "getex", "sort", "zmscore", "sdiffstore", "msetnx", "substr",
+        "zrangestore", "zunion", "echo", "zdiff", "sunionstore", "smismember",
         "hrandfield", "geosearchstore", "zdiffstore", "geosearch", "randomkey", "zinter", "zrandmember",
-        "bitop", "xclaim", "lpos", "renamenx", "xgroup","xreadnonblock");
+        "bitop", "lpos", "renamenx","xread_simple_command");
   }
 
   /**
@@ -93,7 +92,7 @@ struct SupportedCommands {
    * @return commands that are called blocking commands but not pubsub commands.
    */
   static const absl::flat_hash_set<std::string>& blockingCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "blpop", "brpop", "brpoplpush", "bzpopmax", "bzpopmin", "xreadblock", "xreadgroup", "blmove");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "blpop", "brpop", "brpoplpush", "bzpopmax", "bzpopmin", "xread_blocking_command", "blmove");
   }
 
   /**
@@ -124,6 +123,20 @@ struct SupportedCommands {
     CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "script", "flushall", "flushdb", "pubsub", "keys", "slowlog", "config", "client", "info", "select", "unwatch");
     }
   
+  /**
+  * @return commands which handle Redis Streams.
+  */
+  static const absl::flat_hash_set<std::string>& streamCommands() {
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "xack", "xadd", "xautoclaim", "xclaim", "xdel", "xgroup", "xinfo", "xlen", "xpending", "xrange", "xread","xreadgroup","xrevrange","xtrim");
+  }
+
+  /**
+  * @return List of stream commands which can be configured in blocking mode.
+  */
+  static const absl::flat_hash_set<std::string>& streamBlockingCommands() {
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "xread","xreadgroup");
+  }
+
   /**
    * @return scan command
    */
@@ -174,10 +187,6 @@ struct SupportedCommands {
    */
   static const std::string& info() { CONSTRUCT_ON_FIRST_USE(std::string, "info"); }
 
-    /**
-   * @return special stream commands
-   */
-  static const std::string& spl_strm_commands() { CONSTRUCT_ON_FIRST_USE(std::string, "xread"); }
   /**
    * @return commands which alters the state of redis
    */

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -360,6 +360,8 @@ private:
   BlockingClientRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
                 bool delay_command_latency)
       : SingleServerRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+  
+ static int32_t getShardingKeyIndex(const std::string command_name,const Common::Redis::RespValue& request);
 
 };
 
@@ -377,6 +379,8 @@ private:
   SimpleRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
                 bool delay_command_latency)
       : SingleServerRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+  
+  static int32_t getShardingKeyIndex(const std::string command_name,const Common::Redis::RespValue& request);
 };
 
 /**
@@ -596,6 +600,8 @@ private:
   void addHandler(Stats::Scope& scope, const std::string& stat_prefix, const std::string& name,
                   bool latency_in_micros, CommandHandler& handler);
   void onInvalidRequest(SplitCallbacks& callbacks);
+
+  HandlerDataPtr getHandlerForStreamsCommand(const std::string& command_name, const Common::Redis::RespValuePtr& request);
 
   RouterPtr router_;
   CommandHandlerFactory<SimpleRequest> simple_command_handler_;

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -113,6 +113,7 @@ public:
   std::unique_ptr<Common::Redis::Utility::DownStreamMetrics> getDownStreamInfo();
   void setclientname(std::string clientname) { clientname_ = clientname; }
   std::string getclientname() { return clientname_; }
+  void closeDownstreamConnection();
 
 private:
   friend class RedisProxyFilterTest;

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -34,7 +34,7 @@ struct RedisHealthCheckerStats {
 /**
  * Redis health checker implementation. Sends PING and expects PONG.
  */
-class RedisHealthChecker : public Upstream::HealthCheckerImplBase {
+class RedisHealthChecker : public Upstream::HealthCheckerImplBase, public Logger::Loggable<Logger::Id::redis>{
 public:
   RedisHealthChecker(
       const Upstream::Cluster& cluster, const envoy::config::core::v3::HealthCheck& config,
@@ -67,7 +67,7 @@ private:
       : public ActiveHealthCheckSession,
         public Extensions::NetworkFilters::Common::Redis::Client::Config,
         public Extensions::NetworkFilters::Common::Redis::Client::ClientCallbacks,
-        public Network::ConnectionCallbacks {
+        public Network::ConnectionCallbacks, public Logger::Loggable<Logger::Id::redis> {
     RedisActiveHealthCheckSession(RedisHealthChecker& parent, const Upstream::HostSharedPtr& host);
     ~RedisActiveHealthCheckSession() override;
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Fixes for Memory leak on Quit , Fix support for Stream commands, Fix Crash 
Additional Description:
This PR has fixes for the following 
1. Memory leak
     There was a memory leak due to proxy filter object not freed , as the downstream callbacks was not cleared . this happened in only when quit command is called . that too quit command without remote close
     A wrapper function was added to free up the downstream objects before closing down stream connections locally

2. Stream command support
     Fixes for properly supporting all stream commands catergory is added. stream blocking and non blocking comands are handled seperately

3.  Possible fixes for Random

     The reason for random crash is identified as trying to access freed memeory
     this is based on the understanding of the last point in which the logs have stopped and result from running address sanitiser , anyhow recomendation would be to still recreate the problem and get a back trace
fixes have been done to not access already freed memory

Risk Level:
Testing:
Basic sanity testing done
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
