### PR TITLE
Fix for handling pubsub message return properly

### DIFF
--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -252,9 +252,11 @@ void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePt
 
   if (request.pending_response_.get()->type() == Common::Redis::RespType::Null && transaction_.isSubscribedMode()){
     ENVOY_LOG(debug,"Null response received from upstream Possible pubsub message processing, ignoring sending response downstream");
+    request.pending_response_.reset();
     pending_requests_.pop_front();
-
+    return;
   }
+
   if (request.pending_response_) {
     if (request.pending_response_->type() != Common::Redis::RespType::Null &&request.pending_response_->type() == Common::Redis::RespType::Error) {
       ENVOY_LOG(info, "error response: '{}'", request.pending_response_->toString());


### PR DESCRIPTION
void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePtr&& value) {
  ASSERT(!pending_requests_.empty());
  request.pending_response_ = std::move(value);
  request.request_handle_ = nullptr;

  if (request.pending_response_.get()->type() == Common::Redis::RespType::Null && transaction_.isSubscribedMode()){
    ENVOY_LOG(debug,"Null response received from upstream Possible pubsub message processing, ignoring sending response downstream");
FIX added -->   request.pending_response_.reset();
    pending_requests_.pop_front();
FIX added  -->   return;
  }
  
    if (request.pending_response_) { <--- <NULL Pointer check will happen 
    if (request.pending_response_->type() != Common::Redis::RespType::Null &&request.pending_response_->type() == Common::Redis::RespType::Error) {
      ENVOY_LOG(info, "error response: '{}'", request.pending_response_->toString());
    }
  }
  
    // The response we got might not be in order, so flush out what we can. (A new response may
  // unlock several out of order responses).
  while (!pending_requests_.empty() && pending_requests_.front().pending_response_) {
    encoder_->encode(*pending_requests_.front().pending_response_, encoder_buffer_);
    pending_requests_.pop_front(); <--- Pop all the other pending requets also
  }

  In this code snippet if we did not return and not free the request.pending_response_
  There would be 2 problems
  1. We would be handling null pointer in this " if (request.pending_response_)" 
  2. If there are more than one requests queued we will continue popping other requests also when processing pubsub response . which will result in assert when handling response of other queued requets