### PR TITLE
fix the gaps in blocking commands within transaction and fix paring o…

### DIFF
--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -280,11 +280,19 @@ struct Transaction {
 
   void setBlockingCommand() {is_blocking_command_ = true;}
 
+  void setDiscardTransaction() { discard_ = true; }
+
+  void setSendDiscardError() { send_discard_error_ = true; }
+
   bool isTransactionMode() { return is_transaction_mode_; }
 
   bool isSubscribedMode() { return is_subscribed_mode_; }
 
   bool isBlockingCommand() { return is_blocking_command_; }
+
+  bool isDiscardTransaction() { return discard_; }
+
+  bool shouldSendDiscardError() { return send_discard_error_; }
 
 
   void close() {
@@ -292,6 +300,8 @@ struct Transaction {
     is_transaction_mode_ = false;
     is_subscribed_mode_ = false;
     is_blocking_command_ = false;
+    discard_ = false;
+    send_discard_error_ = false;
     key_.clear();
     if (connection_established_) {
       for (auto& client : clients_) {
@@ -320,6 +330,8 @@ struct Transaction {
   }
 
   bool active_{false};
+  bool discard_{false};
+  bool send_discard_error_{false};
   bool connection_established_{false};
   bool should_close_{false};
   bool is_blocking_command_{false};

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -113,7 +113,7 @@ struct SupportedCommands {
   * @return client sub commands thats supported 
   */
   static const absl::flat_hash_set<std::string>& clientSubCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "getname", "list","setname");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "getname","setname");
   }
 
     /**

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -20,7 +20,7 @@ struct SupportedCommands {
    */
   static const absl::flat_hash_set<std::string>& simpleCommands() {
     CONSTRUCT_ON_FIRST_USE(
-        absl::flat_hash_set<std::string>, "append", "bitcount", "bitfield", "bitpos", "decr",
+        absl::flat_hash_set<std::string>, "append", "bitcount", "bitfield", "bitpos", "copy", "decr",
         "decrby", "dump", "expire", "expireat", "geoadd", "geodist", "geohash", "geopos",
         "georadius_ro", "georadiusbymember_ro", "get", "getbit", "getdel", "getrange", "getset",
         "hdel", "hexists", "hget", "hgetall", "hincrby", "hincrbyfloat", "hkeys", "hlen", "hmget",

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -64,7 +64,7 @@ struct SupportedCommands {
    * @return commands which handle Redis transactions allowed non simple commands.
    */
   static const absl::flat_hash_set<std::string>& transactionAllowedNonSimpleCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "del", "exists", "touch", "unlink", "xack", "xadd", "xautoclaim", "xclaim", "xdel", "xgroup", "xinfo", "xlen", "xpending", "xrange", "xrevrange","xtrim");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "del", "exists", "touch", "unlink", "xack", "xadd", "xautoclaim", "xclaim", "xdel", "xgroup", "xinfo", "xlen", "xpending", "xrange", "xrevrange","xtrim","eval", "evalsha","xread","xreadgroup","blpop", "brpop", "brpoplpush", "bzpopmax", "bzpopmin","blmove","mset","mget");
   }
 
    /**

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -78,7 +78,7 @@ struct SupportedCommands {
    * @return commands allowed when a client is in subscribed state.
    */
   static const absl::flat_hash_set<std::string>& subcrStateallowedCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "subscribe", "psubscribe", "unsubscribe", "punsubscribe","quit", "ping","reset");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "subscribe", "psubscribe", "unsubscribe", "punsubscribe","quit", "ping");
   }
 
   /**

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -1636,7 +1636,7 @@ void SplitKeysSumResultRequest::onChildResponse(Common::Redis::RespValuePtr&& va
   }
 }
 
-int32_t TransactionRequest::getShardingKeyIndex(const std::string command_name, const Common::Redis::RespValue& request) {
+int32_t TransactionRequest::getShardingKeyIndex(const std::string& command_name, const Common::Redis::RespValue& request) {
     if (command_name == "xread" || command_name == "xreadgroup") {
         int32_t count = request.asArray().size();
         for (int32_t index = 0; index < count; ++index) {
@@ -1655,7 +1655,13 @@ int32_t TransactionRequest::getShardingKeyIndex(const std::string command_name, 
         } else {
             return -1;  // Not enough elements
         }
-    } else {
+    } else if(Common::Redis::SupportedCommands::evalCommands().contains(command_name)) {
+      if (!(request.asArray().size() < 4)) {
+        return 3;  // Return index 3 for eval commands
+      } else {
+        return -1;  // Not enough arguments to process in transaction
+      }
+    }else {
         return 1;  // Default case for other commands
     }
 }

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -415,6 +415,7 @@ private:
   TransactionRequest(SplitCallbacks& callbacks, CommandStats& command_stats,
                      TimeSource& time_source, bool delay_command_latency)
       : SingleServerRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+  static int32_t getShardingKeyIndex(const std::string command_name,const Common::Redis::RespValue& request);
 };
 
 /**

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -415,7 +415,7 @@ private:
   TransactionRequest(SplitCallbacks& callbacks, CommandStats& command_stats,
                      TimeSource& time_source, bool delay_command_latency)
       : SingleServerRequest(callbacks, command_stats, time_source, delay_command_latency) {}
-  static int32_t getShardingKeyIndex(const std::string command_name,const Common::Redis::RespValue& request);
+  static int32_t getShardingKeyIndex(const std::string& command_name,const Common::Redis::RespValue& request);
 };
 
 /**


### PR DESCRIPTION
Fixed the following 

Fix for crash when giving publish command when in subscribed mode  -- Important

When Giving streams command within transaction the key index was not choose correct for some stream commands like xgroup , xinfo , if it was first command -- Important

when parsing stream commands to check if it has block option , we were checking in correctly at only fixed offsets for BLOCK key word , while the BLOCK can be present at any offset before the STREAMS key word , This is fixed. - Important

For the transaction commands 
all the blocking commands are now allowed in to transaction , as the redis itself takes care of converting it in to non blocking 
mset and mget are added , as cross slot errors are handled by redis itself
To maintain atomicity of the transaction , if any of the unsupported commands are given at the middle of a valid transaction , when exec command is given at the last its replaced with DISCARD command, so that the transaction is discared , and also the response  for DISCARD is just ok , this is unacceptable , so thats also caught and converted to proper error message. - On Need Basis

But still many commands which is handled before transaction iteself is left untouched and they are considered to be not supported within transaction  - On Need Basis