### PR TITLE
remove assert and add logs when response received after request flushed

### DIFF
--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -159,6 +159,7 @@ private:
   bool connection_allowed_;
   Common::Redis::Client::Transaction transaction_;
   bool connection_quit_;
+  bool request_cancelled_{false};
   std::string clientname_{};
 };
 


### PR DESCRIPTION
In production we have seen scenarios where the response is received while there was no pending request tied to it
this could happen in very corner cases of race condition , where a connection close event and the response handling is triggered at the same time 
The work arround is to remove the assert and replace it with error logs to see what response is received and adding variables to check if it was followed by request flushing 