### PR TITLE
add more logs to debug the assert failure problem for fresh chat iter1

### DIFF
--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -269,6 +269,10 @@ void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePt
     return;
   }
 
+  if (request.pending_response_.get()->type() != Common::Redis::RespType::Null && transaction_.isSubscribedMode()){
+    ENVOY_LOG(error,"Non null response received for pubsub command: : '{}' ",request.pending_response_->toString());
+  }
+
   if (request.pending_response_) {
     if (request.pending_response_->type() != Common::Redis::RespType::Null &&request.pending_response_->type() == Common::Redis::RespType::Error) {
       ENVOY_LOG(info, "error response: '{}'", request.pending_response_->toString());


### PR DESCRIPTION
Based on the analysis so far the possibility of race condition is ruled out 
but there is a possibility that , an error response is sent and then a null response is sent 
also ideally when in pubsub , only null response would be sent via normal proxy filter path 
so added logs to print any reponse other than null, which can give clue of sequence of commands leading to this situation