### PR TITLE
fix in scan command and support for redis insights

### DIFF
--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -1383,7 +1383,7 @@ SplitRequestPtr ScanRequest::create(Router& router, Common::Redis::RespValuePtr&
 
   // Iterate over the arguments and validate
   for (size_t i = 2; i < incoming_request->asArray().size(); i++) {
-    std::string arg = incoming_request->asArray()[i].asString();
+    std::string arg = absl::AsciiStrToLower(incoming_request->asArray()[i].asString());
     std::string value = incoming_request->asArray()[++i].asString();
 
     if (!validateArgument(arg, value)) {


### PR DESCRIPTION
when parsing the arguments of scan command and checking the validity of the arguments 
the arguments were not converted to lower case before doing any operations to make it case insentive
this resulted in failure when giving MATCH and COUNT argument in caps
this is a not a critical problem as it will usually be a manual command , But Tools which use this may fail
This also failed redis insights to work properly , This fix solves this