### PR TITLE
replace assert with if check to avoid crash when connection is not open

### DIFF
--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -174,7 +174,11 @@ PoolRequest* ClientImpl::makeRequest(const RespValue& request, ClientCallbacks& 
 
 
 bool ClientImpl::makePubSubRequest(const RespValue& request) {
-  ASSERT(connection_->state() == Network::Connection::State::Open);
+  //ASSERT(connection_->state() == Network::Connection::State::Open);
+  if (connection_->state() != Network::Connection::State::Open) {
+    ENVOY_LOG(error, "Pubsub Client Connection not open yet for makePubSubRequest");
+    return false;
+  }
 
   const bool empty_buffer = encoder_buffer_.length() == 0;
 


### PR DESCRIPTION
In envoy the upstream connection creation is an asynchronous process , where the connection initiation is done as part of code flow , but it doesn't wait for connection completion (TCP 3 Way handshake). This has been the design of envoy from day 1 . where if the connection timeout , it will be intimated to downstream clients and clients has to retry

the current code flow checks for socket creation before buffering request until connection is established, as socket creation has to be immediate it was not considered a problem. 
in some rare occasions where the socket creation takes time, the make request method may be hit even before the socket is created , current code handles this by assertion . But since assertion causes envoy restart, we need to fix it

this kind of race condition is likely to happen for pubsub implementation as opposed to regular command handling because, pubsub always  ends in creating connections where regular commands use clients in pool

the fix is to avoid the assert and return error for clients to retry