### PR TITLE
DR-0000 - Initial commit - Pubsub assert & segfault fixes

### DIFF
--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -303,14 +303,12 @@ struct Transaction {
     discard_ = false;
     send_discard_error_ = false;
     key_.clear();
-    if (connection_established_) {
-      for (auto& client : clients_) {
-        if (client != nullptr) {
-          client->close();
-        }
+    for (auto& client : clients_) {
+      if (client != nullptr) {
+        client->close();
       }
-      connection_established_ = false;
     }
+    connection_established_ = false;
     should_close_ = false;
   }
   void setDownstreamCallback(std::shared_ptr<DirectCallbacks> callback) {

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -109,6 +109,9 @@ ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dis
 }
 
 ClientImpl::~ClientImpl() {
+  if (connection_ && connection_->state() != Network::Connection::State::Closed) {
+    finalizeConnectionClose();
+  }
   ASSERT(pending_requests_.empty());
   ASSERT(connection_->state() == Network::Connection::State::Closed);
   host_->cluster().trafficStats()->upstream_cx_active_.dec();
@@ -118,11 +121,17 @@ ClientImpl::~ClientImpl() {
 }
 
 void ClientImpl::close() {
+  if (closing_) {
+    // onEvent(RemoteClose) may have set closing_ before transaction.close() re-enters here.
+    // Still finalize the connection so ~ClientImpl() does not assert on connection state.
+    finalizeConnectionClose();
+    return;
+  }
+  closing_ = true;
+  drainPendingRequests();
   pubsub_cb_.reset();
   ENVOY_LOG(debug, "Upstream Client Connection close requested");
-  if (connection_) {
-    connection_->close(Network::ConnectionCloseType::NoFlush); 
-  }
+  finalizeConnectionClose();
 }
 
 void ClientImpl::flushBufferAndResetTimer() {
@@ -216,6 +225,10 @@ bool ClientImpl::makePubSubRequest(const RespValue& request) {
 
 void ClientImpl::onConnectOrOpTimeout() {
 
+  if (closing_) {
+    return;
+  }
+
   putOutlierEvent(Upstream::Outlier::Result::LocalOriginTimeout);
   if (connected_) {
     host_->cluster().trafficStats()->upstream_rq_timeout_.inc();
@@ -244,6 +257,10 @@ void ClientImpl::onConnectOrOpTimeout() {
 }
 
 void ClientImpl::onData(Buffer::Instance& data) {
+  if (closing_) {
+    return;
+  }
+
   TRY_NEEDS_AUDIT { decoder_->decode(data); }
   END_TRY catch (ProtocolError&) {
     putOutlierEvent(Upstream::Outlier::Result::ExtOriginRequestFailed);
@@ -260,9 +277,41 @@ void ClientImpl::putOutlierEvent(Upstream::Outlier::Result result) {
   }
 }
 
+void ClientImpl::drainPendingRequests() {
+  while (!pending_requests_.empty()) {
+    PendingRequest& request = pending_requests_.front();
+    ENVOY_LOG(debug, "Upstream Client draining pending request on close");
+    if (!request.canceled_) {
+      ENVOY_LOG(info, "Upstream Client Connection close calling onFailure");
+      request.callbacks_.onFailure();
+    } else {
+      host_->cluster().trafficStats()->upstream_rq_cancelled_.inc();
+    }
+    pending_requests_.pop_front();
+  }
+}
+
+void ClientImpl::finalizeConnectionClose() {
+  connect_or_op_timer_->disableTimer();
+  if (flush_timer_->enabled()) {
+    flush_timer_->disableTimer();
+  }
+  if (connection_) {
+    connection_->removeConnectionCallbacks(*this);
+    if (connection_->state() != Network::Connection::State::Closed) {
+      connection_->close(Network::ConnectionCloseType::NoFlush);
+    }
+  }
+}
+
 void ClientImpl::onEvent(Network::ConnectionEvent event) {
+  if (closing_) {
+    return;
+  }
+
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
+    closing_ = true;
 
     std::string eventTypeStr = (event == Network::ConnectionEvent::RemoteClose ? "RemoteClose" : "LocalClose");
     ENVOY_LOG(debug,"Upstream Client Connection close event received:'{}'",eventTypeStr);
@@ -273,11 +322,22 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
         putOutlierEvent(Upstream::Outlier::Result::LocalOriginConnectFailed);
       }
     }
+
+    if (is_transaction_client_) {
+      ENVOY_LOG(debug, "transaction client {}", is_transaction_client_);
+      //TODO - Handle transaction client upstream client failures here..
+    }
+
+    // Drain setup requests (AUTH, READONLY) before pubsub failure handling, which may destroy
+    // this client synchronously. This prevents the ~ClientImpl() ASSERT(pending_requests_.empty())
+    // and the reentrant-destruction crash seen on pubsub upstream remote close.
+    drainPendingRequests();
+
     // If client is Pubsub handle the upstream close event such that downstream must also be closed.
-    if ( is_pubsub_client_) {
+    if (is_pubsub_client_) {
       host_->cluster().trafficStats()->upstream_cx_destroy_with_active_rq_.inc();
       ENVOY_LOG(debug,"Pubsub Client Connection close event received:'{}', clearing pubsub_cb_",eventTypeStr);
-      //clear pubsub_cb_ be it either local or remote close       
+      //clear pubsub_cb_ be it either local or remote close
       if ((pubsub_cb_ != nullptr)&&(event == Network::ConnectionEvent::RemoteClose)){
         ENVOY_LOG(debug,"Pubsub Client Remote close received on Downstream Notify Upstream and close it");
         pubsub_cb_->onFailure();
@@ -285,25 +345,7 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
       pubsub_cb_.reset();
     }
 
-    if (is_transaction_client_) {
-      ENVOY_LOG(debug, "transaction client {}", is_transaction_client_);
-      //TODO - Handle transaction client upstream client failures here..
-    }
-
-    //handle non blocking and non transaction requests
-    while (!pending_requests_.empty()) { 
-      PendingRequest& request = pending_requests_.front();
-      ENVOY_LOG(debug,"Upstream Client Connection close ");
-      if (!request.canceled_) {
-        ENVOY_LOG(info,"Upstream Client Connection close calling onFailure");
-        request.callbacks_.onFailure();
-      } else {
-        host_->cluster().trafficStats()->upstream_rq_cancelled_.inc();
-      }
-      pending_requests_.pop_front();
-    }
-
-    connect_or_op_timer_->disableTimer();
+    finalizeConnectionClose();
     
   } else if (event == Network::ConnectionEvent::Connected) {
     connected_ = true;
@@ -324,8 +366,37 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
 }
 
 void ClientImpl::onRespValue(RespValuePtr&& value) {
+  if (closing_) {
+    return;
+  }
+
   int32_t clientIndex = getCurrentClientIndex();
   if (is_pubsub_client_) {
+    // AUTH and READONLY setup commands are sent via makeRequest() during initialize() and are
+    // tracked in pending_requests_. Their responses (OK / Error) must be drained here, otherwise
+    // pending_requests_ stays non-empty for the lifetime of the pubsub connection and triggers
+    // ASSERT(pending_requests_.empty()) in ~ClientImpl() on close.
+    if (!pending_requests_.empty()) {
+      const bool is_setup_ok = value->type() == Common::Redis::RespType::SimpleString &&
+                               value->asString() == "OK";
+      const bool is_setup_error = value->type() == Common::Redis::RespType::Error;
+      if (is_setup_ok || is_setup_error) {
+        PendingRequest& request = pending_requests_.front();
+        if (config_.enableCommandStats()) {
+          redis_command_stats_->updateStats(scope_, request.command_, is_setup_ok);
+          request.command_request_timer_->complete();
+        }
+        request.aggregate_request_timer_->complete();
+        pending_requests_.pop_front();
+        if (pending_requests_.empty() && connect_or_op_timer_->enabled()) {
+          connect_or_op_timer_->disableTimer();
+        }
+        putOutlierEvent(is_setup_ok ? Upstream::Outlier::Result::ExtOriginRequestSuccess
+                                    : Upstream::Outlier::Result::ExtOriginRequestFailed);
+        return;
+      }
+    }
+
     // This is a pubsub client, and we have received a message from the server.
     // We need to pass this message to the registered callback.
     if (pubsub_cb_ != nullptr){

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -137,6 +137,8 @@ private:
   void onConnectOrOpTimeout();
   void onData(Buffer::Instance& data);
   void putOutlierEvent(Upstream::Outlier::Result result);
+  void drainPendingRequests();
+  void finalizeConnectionClose();
 
   // DecoderCallbacks
   void onRespValue(RespValuePtr&& value) override;
@@ -162,6 +164,7 @@ private:
   bool is_transaction_client_;
   bool is_pubsub_client_=false;
   bool is_blocking_client_=false;
+  bool closing_{false};
   std::shared_ptr<Extensions::NetworkFilters::Common::Redis::Client::PubsubCallbacks> pubsub_cb_=nullptr;
   int32_t current_shard_index_{-1};
 };

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -238,14 +238,13 @@ void ProxyFilter::closeDownstreamConnection() {
 }
 void ProxyFilter::onPubsubConnClose(){
   ASSERT(pending_requests_.empty());
-//Close the downstream connection on upstream connection close 
   transaction_.setPubSubCallback(nullptr);
-  //callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
-  //This callback is called only on remote close , so no need to close the client connnection again
-  transaction_.connection_established_=false;
   connection_quit_ = false;
+  // Close all upstream pubsub clients (including other shards) before tearing down
+  // downstream. Do not clear connection_established_ first; Transaction::close()
+  // only closes clients while that flag is still true.
+  transaction_.close();
   this->closeDownstreamConnection();
-  return;
 }
 
 void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePtr&& value) {

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -33,6 +33,13 @@ namespace Common {
 namespace Redis {
 namespace Client {
 
+class MockPubsubCallbacks : public PubsubCallbacks {
+public:
+  MOCK_METHOD(void, handleChannelMessage,
+              (Common::Redis::RespValuePtr&& value, int32_t client_index), (override));
+  MOCK_METHOD(void, onFailure, (), (override));
+};
+
 class RedisClientImplTest : public testing::Test,
                             public Event::TestUsingSimulatedTime,
                             public Common::Redis::DecoderFactory {
@@ -61,6 +68,15 @@ public:
   }
 
   void finishSetup() {
+    finishSetupWithClientType(false, false, nullptr);
+  }
+
+  void finishSetupPubsub(const std::shared_ptr<PubsubCallbacks>& pubsub_cb) {
+    finishSetupWithClientType(false, true, pubsub_cb);
+  }
+
+  void finishSetupWithClientType(bool is_transaction_client, bool is_pubsub_client,
+                                 const std::shared_ptr<PubsubCallbacks>& pubsub_cb) {
     upstream_connection_ = new NiceMock<Network::MockClientConnection>();
     Upstream::MockHost::MockCreateConnectionData conn_info;
     conn_info.connection_ = upstream_connection_;
@@ -80,10 +96,13 @@ public:
         Common::Redis::RedisCommandStats::createRedisCommandStats(stats_.symbolTable());
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
-                                 *config_, redis_command_stats_, *stats_.rootScope(), false);
+                                 *config_, redis_command_stats_, *stats_.rootScope(),
+                                 is_transaction_client, is_pubsub_client, false, pubsub_cb);
     EXPECT_EQ(1UL, host_->cluster_.traffic_stats_->upstream_cx_total_.value());
     EXPECT_EQ(1UL, host_->stats_.cx_total_.value());
-    EXPECT_EQ(false, client_->active());
+    if (!is_pubsub_client) {
+      EXPECT_EQ(false, client_->active());
+    }
 
     // NOP currently.
     upstream_connection_->runHighWatermarkCallbacks();
@@ -1204,6 +1223,69 @@ TEST_F(RedisClientImplTest, RemoveFailedHost) {
   EXPECT_CALL(*connect_or_op_timer_, disableTimer());
   EXPECT_CALL(connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
   upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+}
+
+// Pubsub clients send AUTH via makeRequest(); OK must drain pending_requests_ or close
+// must drain before onFailure() to avoid ~ClientImpl() assert (prod crash).
+TEST_F(RedisClientImplTest, PubsubAuthOkDrainsPendingRequest) {
+  InSequence s;
+
+  auto pubsub_cb = std::make_shared<NiceMock<MockPubsubCallbacks>>();
+  config_ = std::make_unique<ConfigImpl>(createConnPoolSettings());
+  finishSetupPubsub(pubsub_cb);
+
+  auth_username_ = "default";
+  auth_password_ = "secret";
+  Utility::AuthRequest auth_request(auth_username_, auth_password_);
+  EXPECT_CALL(*encoder_, encode(Eq(auth_request), _));
+  EXPECT_CALL(*flush_timer_, enabled()).WillOnce(Return(false));
+  client_->initialize(auth_username_, auth_password_);
+
+  onConnected();
+
+  Common::Redis::RespValuePtr auth_ok{new Common::Redis::RespValue()};
+  auth_ok->type(Common::Redis::RespType::SimpleString);
+  auth_ok->asString() = "OK";
+  ClientImpl* client_impl = dynamic_cast<ClientImpl*>(client_.get());
+  ASSERT_NE(client_impl, nullptr);
+  EXPECT_CALL(host_->outlier_detector_,
+              putResult(Upstream::Outlier::Result::ExtOriginRequestSuccess, _));
+  client_impl->onRespValue(std::move(auth_ok));
+
+  EXPECT_CALL(*pubsub_cb, onFailure());
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer());
+  EXPECT_CALL(*upstream_connection_, removeConnectionCallbacks(_));
+  EXPECT_CALL(*upstream_connection_, state())
+      .WillRepeatedly(Return(Network::Connection::State::Closed));
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  client_.reset();
+}
+
+TEST_F(RedisClientImplTest, PubsubRemoteCloseWithPendingAuthSurvivesDestroy) {
+  InSequence s;
+
+  auto pubsub_cb = std::make_shared<NiceMock<MockPubsubCallbacks>>();
+  config_ = std::make_unique<ConfigImpl>(createConnPoolSettings());
+  finishSetupPubsub(pubsub_cb);
+
+  auth_password_ = "secret";
+  Utility::AuthRequest auth_request(auth_password_);
+  EXPECT_CALL(*encoder_, encode(Eq(auth_request), _));
+  EXPECT_CALL(*flush_timer_, enabled()).WillOnce(Return(false));
+  client_->initialize(auth_username_, auth_password_);
+
+  onConnected();
+
+  // AUTH still in flight (pending_requests_ non-empty) — reproduces prod close path.
+  EXPECT_CALL(*pubsub_cb, onFailure()).WillOnce(Invoke([this]() { client_->close(); }));
+  EXPECT_CALL(*connect_or_op_timer_, disableTimer()).Times(testing::AtLeast(1));
+  EXPECT_CALL(*upstream_connection_, removeConnectionCallbacks(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(*upstream_connection_, state())
+      .WillRepeatedly(Return(Network::Connection::State::Closed));
+  upstream_connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  client_.reset();
 }
 
 TEST(RedisClientFactoryImplTest, Basic) {


### PR DESCRIPTION
## Fix: Redis Proxy Pub/Sub Upstream Connection Close Crash

### Problem

When a downstream Redis client issues `SUBSCRIBE` or `PSUBSCRIBE` through
Envoy's redis-proxy, Envoy opens **dedicated upstream `ClientImpl` connections**
per Redis cluster shard. If an upstream Redis node closes the connection
(`RemoteClose`) while pub/sub is active, Envoy crashed with one of:

- **DEBUG builds:** `assert failure: pending_requests_.empty()` in `ClientImpl::~ClientImpl()`
- **DEBUG builds:** `assert failure: connection_->state() == Network::Connection::State::Closed` in `ClientImpl::~ClientImpl()`
- **RELEASE builds:** Segfault in `ClientImpl::onEvent()` during deferred object destruction

---

### Root Causes

Three bugs compounded each other, each required for the full crash:

#### Bug 1 — Wrong teardown order in `ClientImpl::onEvent()` (client_impl.cc)

`pubsub_cb_->onFailure()` was called **before** draining `pending_requests_`.
`onFailure()` synchronously unwinds into `ProxyFilter::onPubsubConnClose()` →
downstream close → `transaction_.close()` → `~ClientImpl()`, while
`pending_requests_` still contained AUTH/READONLY setup entries.
The destructor assert `pending_requests_.empty()` fired.

#### Bug 2 — AUTH/READONLY responses never popped in pub/sub `onRespValue()` (client_impl.cc)

Pub/sub clients use two request APIs:
- `makeRequest()` for `AUTH` and `READONLY` during `initialize()` → tracked in `pending_requests_[]`
- `makePubSubRequest()` for `SUBSCRIBE`/`PSUBSCRIBE` → **not** tracked

Before this fix, `onRespValue()` on a pub/sub client forwarded **all** responses
to `PubSubMessageHandler`, which silently ignored bare `OK` strings. The matching
`PendingRequest` entries for `AUTH` and `READONLY` were **never popped**, leaving
`pending_requests_` permanently non-empty for the lifetime of every authenticated
pub/sub connection.

#### Bug 3 — `onPubsubConnClose()` cleared `connection_established_` before teardown (proxy_filter.cc / client.h)

`ProxyFilter::onPubsubConnClose()` set `transaction_.connection_established_ = false`
**before** calling `transaction_.close()`. `Transaction::close()` was guarded by
that flag and skipped closing all upstream pub/sub clients in `clients_[]`.
Those `ClientImpl` objects were then destroyed via `~Transaction()` with TCP
connections still `Open`, triggering the second destructor assert.

This was especially severe with all-shard `PSUBSCRIBE` (keyspace notifications),
where `clients_[]` contains one `ClientImpl` per Redis shard — all skipped.

---

### Fixes

#### `source/extensions/filters/network/common/redis/client_impl.cc`

- **Added `drainPendingRequests()`** — extracts the pending-request drain loop
  into a dedicated helper.
- **Reordered `onEvent()` close path** — drain `pending_requests_` first, then
  call `pubsub_cb_->onFailure()`. Fixes Bug 1.
- **Added `finalizeConnectionClose()`** — centralized helper that disables
  timers, removes connection callbacks, and closes the socket only if not
  already closed.
- **Improved `close()`** — idempotent via `closing_` flag; calls
  `drainPendingRequests()` and `finalizeConnectionClose()`. Re-entrant calls
  (from `onEvent` → `transaction.close()` → `client->close()`) call
  `finalizeConnectionClose()` and return safely.
- **Drained AUTH/READONLY in pub/sub `onRespValue()`** — if `pending_requests_`
  is non-empty and the response is `OK` or `Error`, pop the front request with
  proper stats/timer completion before pub/sub message routing. Fixes Bug 2.
- **Added `closing_` early-return guards** in `onEvent()`, `onData()`,
  `onRespValue()`, and `onConnectOrOpTimeout()`. Fixes Bug 3 reentrance.
- **Destructor safety net** — if connection is still open at `~ClientImpl()`,
  call `finalizeConnectionClose()` before the asserts.

#### `source/extensions/filters/network/common/redis/client_impl.h`

- Declared `drainPendingRequests()` and `finalizeConnectionClose()` as private
  helpers.
- Added `bool closing_{false}` member.

#### `source/extensions/filters/network/common/redis/client.h`

- `Transaction::close()` now **always** iterates and closes non-null entries in
  `clients_[]`, unconditionally, before clearing `connection_established_`.
  Previously, this loop was gated on the flag, which could be cleared prematurely
  by `onPubsubConnClose()`. Fixes Bug 3.

#### `source/extensions/filters/network/redis_proxy/proxy_filter.cc`

- `onPubsubConnClose()` now calls `transaction_.close()` **before**
  `closeDownstreamConnection()`, and no longer clears `connection_established_`
  manually (that is done inside `Transaction::close()`). All upstream pub/sub
  clients are explicitly closed before the downstream connection is torn down.
  Fixes Bug 3.

#### `test/extensions/filters/network/common/redis/client_impl_test.cc`

- **`PubsubAuthOkDrainsPendingRequest`** — verifies that an AUTH `OK` response
  on a pub/sub client pops the corresponding `PendingRequest` and does not
  forward to the pub/sub callback.
- **`PubsubRemoteCloseWithPendingAuthSurvivesDestroy`** — verifies that a
  `RemoteClose` with a pending AUTH request and a re-entrant `close()` from
  `onFailure()` completes without asserting, simulating the production crash
  scenario end-to-end.

---

### Testing

**Integration test script** (`tools/redis_pubsub_upstream_close_test.py`):

```bash
# Aggressive mode: 10 concurrent subscribers, all-shard PSUBSCRIBE, SIGKILL one Redis node
python3 tools/redis_pubsub_upstream_close_test.py --aggressive --loop 5